### PR TITLE
fix for Linux

### DIFF
--- a/lib/museum_provenance.rb
+++ b/lib/museum_provenance.rb
@@ -7,7 +7,7 @@ require 'date_time_precision/format/iso8601'
 require 'date_time_precision/format/string'
 require 'active_support/core_ext/integer/inflections'
 
-Dir["#{File.dirname(__FILE__)}/museum_provenance/**/*.rb"].each { |f| require(f) }
+Dir["#{File.dirname(__FILE__)}/museum_provenance/**/*.rb"].sort.each { |f| require(f) }
 
 # MuseumProvenance is a general-purpose library for cultural institutions 
 # @todo Write this, please.


### PR DESCRIPTION
On my Debian system, I get this error when trying to require museum_provenance:

/home/jeffchiu/museum_provenance/lib/museum_provenance/acquisition_method_list.rb:4:in `<class:AcquisitionMethod>': uninitialized constant MuseumProvenance::AcquisitionMethod::Prefix (NameError)
	from /home/jeffchiu/museum_provenance/lib/museum_provenance/acquisition_method_list.rb:2:in `<module:MuseumProvenance>'
	from /home/jeffchiu/museum_provenance/lib/museum_provenance/acquisition_method_list.rb:1:in `<top (required)>'
	from /home/jeffchiu/museum_provenance/lib/museum_provenance.rb:10:in `require'
	from /home/jeffchiu/museum_provenance/lib/museum_provenance.rb:10:in `block in <top (required)>'
	from /home/jeffchiu/museum_provenance/lib/museum_provenance.rb:10:in `each'
	from /home/jeffchiu/museum_provenance/lib/museum_provenance.rb:10:in `<top (required)>'
	from testo.rb:2:in `require'
	from testo.rb:2:in `<main>'

This is because on Mac OS, the following line returns an array of files in alphabetical order, but on Linux, the order is random:

Dir["#{File.dirname(__FILE__)}/museum_provenance/**/*.rb"].each { |f| require(f) }

This PR sorts the file list, to get the same behavior on Linux.
